### PR TITLE
feat : 지원되지 파일 형식을 추가할 경우  toast 라이브러리 통해 알림 표시 (refs #26)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "react-pdf": "^10.0.1",
     "react-resizable-panels": "^3.0.3",
     "react-router-dom": "^7.6.3",
+    "react-toastify": "^11.0.5",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/frontend/src/components/panels/FileView.jsx
+++ b/frontend/src/components/panels/FileView.jsx
@@ -35,6 +35,8 @@ import {
   uploadTextfiles,
   getNodesBySourceId
 } from '../../../../backend/api/backend'
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 
@@ -355,6 +357,7 @@ export default function FileView({
       // 지원하지 않는 확장자는 무시
       if (!['pdf', 'txt', 'memo'].includes(ext)) {
         console.warn(`❌ 지원되지 않는 파일 형식: .${ext}`);
+        toast.error('지원되지 않는 파일 형식입니다. 소스를 추가할 수 없습니다.');
         return;
       }
 
@@ -549,6 +552,7 @@ export default function FileView({
           isLoading={isDeleting}
         />
       )}
+      <ToastContainer position="top-right" autoClose={2000} hideProgressBar={true} />
     </div>
   )
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #26 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
지원되지 않는 파일 형식 (ex) hwp, docs) 등을 소스패널로 드래그했을 때 사용자에게 toast 알림 뜨게 구현 