### PR TITLE
fix : neo4j에 브레인 데이터가 없으면 브레인 이동할 때 404뜨는 버그 해결 (refs #45)

### DIFF
--- a/backend/routers/brainGraph.py
+++ b/backend/routers/brainGraph.py
@@ -44,10 +44,13 @@ async def get_brain_graph(brain_id: str):
         graph_data = neo4j_handler.get_brain_graph(brain_id)
         logging.info(f"Neo4j에서 받은 데이터: nodes={len(graph_data['nodes'])}, links={len(graph_data['links'])}")
         
+        # if not graph_data['nodes'] and not graph_data['links']:
+        #     logging.warning(f"brain_id {brain_id}에 대한 데이터가 없습니다")
+        #     raise GraphDataNotFoundException(brain_id)
+        
         if not graph_data['nodes'] and not graph_data['links']:
             logging.warning(f"brain_id {brain_id}에 대한 데이터가 없습니다")
-            raise GraphDataNotFoundException(brain_id)
-        
+
         return graph_data
     except AppException as ae:
             raise ae

--- a/frontend/api/graphApi.js
+++ b/frontend/api/graphApi.js
@@ -14,18 +14,8 @@ export const fetchGraphData = async (brainId) => {
   } catch (error) {
     console.error('그래프 데이터 가져오기 실패:', error);
 
-    // 샘플 데이터로 폴백
-    return {
-      nodes: [
-        { id: 'sample1', name: '샘플 노드 1', group: 1 },
-        { id: 'sample2', name: '샘플 노드 2', group: 2 },
-        { id: 'sample3', name: '샘플 노드 3', group: 3 }
-      ],
-      links: [
-        { source: 'sample1', target: 'sample2', relation: '관계 1' },
-        { source: 'sample2', target: 'sample3', relation: '관계 2' }
-      ]
-    };
+    // 더미 데이터로 폴백
+    return getDefaultGraphData();
   }
 };
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #45 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
neo4j에 브레인 데이터가 없으면 브레인 이동할 때 404뜨는 버그가 있었는데 brainGraph.py에서 노드랑 엣지가 0이면 무조건 404 에러 뜨게 설정해서 나오는 오류여서 주석처리해서 해결함

## 💬리뷰 요구사항(선택)

> 없음
