### PR TITLE
62 패널 준비 상태에 채팅 그래프 패널 로딩까지 포함

### DIFF
--- a/frontend/src/components/layout/AppHeader.css
+++ b/frontend/src/components/layout/AppHeader.css
@@ -64,11 +64,12 @@
 
 /* ───────── 현재 시간 스타일 ───────── */
 .current-time {
-    font-size: 1.0rem;
+    font-size: 1.02rem;
     font-weight: bold;
     color: #545454;
     letter-spacing: 0.02em;
-    margin-right: 10px;
+    margin-left: -5px;
+    margin-right: 15px;
     font-family: inherit;
 }
 

--- a/frontend/src/components/layout/MainLayout.jsx
+++ b/frontend/src/components/layout/MainLayout.jsx
@@ -77,7 +77,9 @@ function MainLayout() {
 
   // 패널 데이터 준비 상태
   const [isSourcePanelReady, setSourcePanelReady] = useState(false); // SourcePanel 준비 상태
-  const allReady = isSourcePanelReady;
+  const [isGraphReady, setGraphReady] = useState(false);
+  const [isChatReady, setChatReady] = useState(false); // ChatPanel 준비 상태
+  const allReady = isSourcePanelReady && isGraphReady && isChatReady;
 
   // 그래프 상태를 외부 윈도우(localStorage)로 동기화
   const syncToStandaloneWindow = (data) => {
@@ -254,6 +256,7 @@ function MainLayout() {
               onReferencedNodesUpdate={onReferencedNodesUpdate}
               allNodeNames={allNodeNames}
               onOpenSource={handleOpenSource}
+              onChatReady={setChatReady}
             />
           </div>
         </Panel>
@@ -278,6 +281,7 @@ function MainLayout() {
               graphRefreshTrigger={graphRefreshTrigger}
               onGraphDataUpdate={handleGraphDataUpdate}
               focusNodeNames={focusNodeNames}
+              onGraphReady={setGraphReady}
             />
           </div>
         </Panel>

--- a/frontend/src/components/panels/Chat/ChatPanel.jsx
+++ b/frontend/src/components/panels/Chat/ChatPanel.jsx
@@ -33,6 +33,7 @@ function ChatPanel({
   onReferencedNodesUpdate,
   allNodeNames = [],
   onOpenSource,
+  onChatReady
 }) {
   // ===== 상태 선언부 =====
   const [brainName, setBrainName] = useState(''); // 브레인 이름
@@ -69,7 +70,14 @@ function ChatPanel({
   // ===== 채팅 내역 불러오기 (프로젝트 변경 시) =====
   useEffect(() => {
     if (!selectedBrainId) return;
-    fetchChatHistory(selectedBrainId).then(setChatHistory);
+    fetchChatHistory(selectedBrainId)
+      .then(history => {
+        setChatHistory(history);
+        if (onChatReady) onChatReady(true);
+      })
+      .catch(() => {
+        if (onChatReady) onChatReady(false);
+      });
   }, [selectedBrainId]);
 
   // ===== 스크롤을 맨 아래로 내리는 함수 =====
@@ -300,15 +308,6 @@ function ChatPanel({
                 value={inputText}
                 onChange={(e) => setInputText(e.target.value)}
                 disabled={isLoading}
-                onKeyDown={e => {
-                  if (e.key === 'Enter' && !e.shiftKey) {
-                    e.preventDefault();
-                    if (!isLoading && inputText.trim()) {
-                      setInputText('');
-                      handleSubmit(e);
-                    }
-                  }
-                }}
               />
               <div className="source-count-text">소스 {sourceCount}개</div>
               <button
@@ -350,15 +349,6 @@ function ChatPanel({
                   placeholder="무엇이든 물어보세요"
                   value={inputText}
                   onChange={(e) => setInputText(e.target.value)}
-                  onKeyDown={e => {
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                      e.preventDefault();
-                      if (inputText.trim()) {
-                        setInputText('');
-                        handleSubmit(e);
-                      }
-                    }
-                  }}
                 />
                 <div className="source-count-text">소스 {sourceCount}개</div>
                 <button

--- a/frontend/src/components/panels/Insight/Graph/GraphView.jsx
+++ b/frontend/src/components/panels/Insight/Graph/GraphView.jsx
@@ -4,6 +4,7 @@ import * as d3 from 'd3';
 import { fetchGraphData } from '../../../../../api/graphApi';
 import { easeCubicInOut } from 'd3-ease';
 import './GraphView.css';
+import { startTimelapse } from './graphTimelapse';
 
 function GraphView({
   brainId = 'default-brain-id',
@@ -17,7 +18,7 @@ function GraphView({
   onTimelapse,
   showPopups = true,
   onNewlyAddedNodes,
-  onGraphViewReady,
+  onGraphReady,
   externalShowReferenced,
   externalShowFocus,
   externalShowNewlyAdded,
@@ -52,10 +53,7 @@ function GraphView({
   const [refPulseStartTime, setRefPulseStartTime] = useState(null);
   const lastClickRef = useRef({ node: null, time: 0 });
   const clickTimeoutRef = useRef();
-
-  // ✅ 콜백 등록 상태 추적
-  const callbacksRegisteredRef = useRef(false);
-  const prevNewlyAddedRef = useRef([]);
+  const [graphReady, setGraphReady] = useState(false); // 그래프 준비 상태
 
   // 색상 팔레트
   // ✅ 다크모드용 색상 팔레트 추가
@@ -71,7 +69,6 @@ function GraphView({
   // ✅ 현재 팔레트 선택
   const colorPalette = isDarkMode ? darkColorPalette : lightColorPalette;
 
-
   // 컨테이너 사이즈 계산
   const updateDimensions = () => {
     if (!containerRef.current) return;
@@ -86,18 +83,6 @@ function GraphView({
     setDimensions({ width, height: calcHeight });
   };
 
-  // const getInitialZoomScale = (nodeCount) => {
-  //   if (nodeCount >= 1000) return 0.045;
-  //   else if (nodeCount >= 500) return 0.05;
-  //   else if (nodeCount >= 100) return 0.07;
-  //   else if (nodeCount >= 50) return 0.15;
-  //   else if (nodeCount >= 40) return 0.2;
-  //   else if (nodeCount >= 30) return 0.25;
-  //   else if (nodeCount >= 20) return 0.3;
-  //   else if (nodeCount >= 10) return 0.4;
-  //   else if (nodeCount >= 5) return 0.8;
-  //   return 1;
-  // };
   const getInitialZoomScale = (nodeCount) => {
     // ✅ Modal용 줌 배율 (더 확대)
     const modalMultiplier = isFullscreen ? 5 : 1.5; // Modal일 때 1.5배 더 확대
@@ -117,66 +102,6 @@ function GraphView({
     return Math.min(baseZoom * modalMultiplier, 5); // 최대 줌 제한
   };
   // 타임랩스 함수
-  const startTimelapse = () => {
-    const nodes = [...graphData.nodes];
-    const links = [...graphData.links];
-    const N = nodes.length;
-    if (N === 0) return;
-
-    const totalDuration = Math.min(6000, 800 + N * 80);
-    const fadeDuration = Math.max(200, Math.min(800, N * 10));
-
-    const shuffledNodes = d3.shuffle(nodes);
-    const appearTimes = shuffledNodes.map((_, i) =>
-      (i / (N - 1)) * (totalDuration - fadeDuration)
-    );
-
-    setIsAnimating(true);
-    setVisibleNodes([]);
-    setVisibleLinks([]);
-
-    if (fgRef.current) {
-      const currentZoom = fgRef.current.zoom();
-      fgRef.current.zoom(currentZoom, 0);
-    }
-
-    const startTime = performance.now();
-
-    const tick = now => {
-      const t = now - startTime;
-      const idx = Math.min(
-        N - 1,
-        Math.floor((t / (totalDuration - fadeDuration)) * (N - 1))
-      );
-
-      const visible = shuffledNodes.slice(0, idx + 1).map((n, i) => {
-        const dt = t - appearTimes[i];
-        const alpha = dt <= 0
-          ? 0
-          : dt >= fadeDuration
-            ? 1
-            : easeCubicInOut(dt / fadeDuration);
-        return { ...n, __opacity: alpha };
-      });
-
-      const visibleIds = new Set(visible.map(n => n.id));
-      const visibleLinks = links.filter(l =>
-        visibleIds.has(l.source) && visibleIds.has(l.target)
-      );
-
-      setVisibleNodes(visible);
-      setVisibleLinks(visibleLinks);
-
-      if (t < totalDuration) {
-        requestAnimationFrame(tick);
-      } else {
-        setIsAnimating(false);
-      }
-    };
-
-    requestAnimationFrame(tick);
-  };
-
   // 노드 클릭 핸들러
   const handleNodeClick = (node) => {
     const now = Date.now();
@@ -199,12 +124,12 @@ function GraphView({
   };
 
   //슬라이더 물리 효과 조절
-  // ✅ 3개 물리 설정만 처리하는 useEffect
+  // 3개 물리 설정만 처리하는 useEffect
   useEffect(() => {
     if (fgRef.current) {
       const fg = fgRef.current;
 
-      // ✅ 올바른 반발력 공식 (0% = 가까이 모임, 100% = 멀리 퍼짐)
+      // 반발력 공식 (0% = 가까이 모임, 100% = 멀리 퍼짐)
       const repelForce = -10 - (repelStrength / 100) * 290;    // 0% = -10, 100% = -300
       const linkDist = 50 + (linkDistance / 100) * 250;        // 50 to 300
       const linkForce = 0.1 + (linkStrength / 100) * 0.9;      // 0.1 to 1.0
@@ -217,7 +142,8 @@ function GraphView({
       fg.d3ReheatSimulation();
     }
   }, [repelStrength, linkDistance, linkStrength]);
-  //예찬 더블 클릭했을 때 줌인되게
+
+  // 더블 클릭했을 때 줌인되게
   useEffect(() => {
     const container = containerRef.current;
     if (!container || !fgRef.current) return;
@@ -280,50 +206,20 @@ function GraphView({
     }
   }, [externalShowNewlyAdded]);
 
-  // ✅ 콜백 등록 - 한 번만 실행되도록 완전히 수정
-  useEffect(() => {
-    if (onGraphViewReady && !callbacksRegisteredRef.current) {
-      console.log('📡 GraphView 콜백 등록 (최초 1회만)');
-
-      // setState 함수들을 직접 전달하지 않고 래퍼 함수로 전달
-      const callbacks = {
-        setShowReferenced: (value) => {
-          console.log('🔄 setShowReferenced 호출:', value);
-          setShowReferenced(value);
-        },
-        setShowFocus: (value) => {
-          console.log('🔄 setShowFocus 호출:', value);
-          setShowFocus(value);
-        },
-        setShowNewlyAdded: (value) => {
-          console.log('🔄 setShowNewlyAdded 호출:', value);
-          setShowNewlyAdded(value);
-        },
-        setNewlyAddedNodeNames: (value) => {
-          console.log('🔄 setNewlyAddedNodeNames 호출:', value);
-          setNewlyAddedNodeNames(value);
-        }
-      };
-
-      onGraphViewReady(callbacks);
-      callbacksRegisteredRef.current = true;
-    }
-  }, []); // ✅ 의존성 배열 완전히 비움
-
   // ✅ 새로 추가된 노드 알림 - 중복 방지 로직 추가
   useEffect(() => {
     if (!onNewlyAddedNodes || newlyAddedNodeNames.length === 0) return;
 
     // 이전 값과 비교해서 실제로 변경된 경우만 알림
-    const prevNodes = prevNewlyAddedRef.current;
+    const prevNodes = prevGraphDataRef.current.nodes.map(n => n.name);
     const isChanged = JSON.stringify(prevNodes) !== JSON.stringify(newlyAddedNodeNames);
 
     if (isChanged) {
       console.log('🆕 새로 추가된 노드 외부 알림:', newlyAddedNodeNames);
       onNewlyAddedNodes(newlyAddedNodeNames);
-      prevNewlyAddedRef.current = [...newlyAddedNodeNames];
+      prevGraphDataRef.current = { ...prevGraphDataRef.current, nodes: [...prevGraphDataRef.current.nodes, ...graphData.nodes.filter(n => newlyAddedNodeNames.includes(n.name))] };
     }
-  }, [newlyAddedNodeNames]); // ✅ onNewlyAddedNodes 의존성 제거
+  }, [newlyAddedNodeNames, graphData.nodes]); // ✅ onNewlyAddedNodes 의존성 제거
 
   // 나머지 useEffect들은 그대로 유지...
   useEffect(() => {
@@ -402,6 +298,7 @@ function GraphView({
   useEffect(() => {
     if (initialGraphData) {
       processGraphData(initialGraphData);
+      setGraphReady(true);
       return;
     }
 
@@ -410,14 +307,21 @@ function GraphView({
         setLoading(true);
         const data = await fetchGraphData(brainId);
         processGraphData(data);
+        setGraphReady(true);
       } catch (err) {
         setError('그래프 데이터를 불러오는 데 실패했습니다.');
         setLoading(false);
+        setGraphReady(false);
       }
     };
 
     loadGraphData();
   }, [brainId, initialGraphData]);
+
+  // graphReady가 바뀔 때마다 부모에 전달
+  useEffect(() => {
+    if (onGraphReady) onGraphReady(graphReady);
+  }, [graphReady, onGraphReady]);
 
   // 그래프 새로고침
   useEffect(() => {
@@ -606,7 +510,7 @@ function GraphView({
 
   // 외부에서 팝업 데이터에 접근할 수 있도록 노출
   React.useImperativeHandle(onTimelapse, () => ({
-    startTimelapse,
+    startTimelapse: () => startTimelapse({ graphData, setIsAnimating, setVisibleNodes, setVisibleLinks, fgRef }),
     getPopupData: () => ({
       showNewlyAdded,
       newlyAddedNodeNames,
@@ -621,13 +525,6 @@ function GraphView({
     })
   }));
 
-  // ✅ 컴포넌트 언마운트 시 정리
-  useEffect(() => {
-    return () => {
-      callbacksRegisteredRef.current = false;
-      prevNewlyAddedRef.current = [];
-    };
-  }, []);
 
   return (
     <div

--- a/frontend/src/components/panels/Insight/Graph/GraphViewWithModal.jsx
+++ b/frontend/src/components/panels/Insight/Graph/GraphViewWithModal.jsx
@@ -4,7 +4,15 @@ import { MdFullscreen, MdClose } from 'react-icons/md';
 import { PiMagicWand } from "react-icons/pi";
 import './GraphViewWithModal.css';
 
-function GraphViewWithModal(props) {
+export default function GraphViewWithModal({
+  brainId,
+  height,
+  referencedNodes,
+  focusNodeNames,
+  graphRefreshTrigger,
+  onGraphDataUpdate,
+  onGraphReady
+}) {
     const [isFullscreen, setIsFullscreen] = useState(false);
     const modalRef = useRef(null);
     const offset = useRef({ x: 0, y: 0 });
@@ -22,43 +30,28 @@ function GraphViewWithModal(props) {
     // GraphView의 상태 감지를 위한 useEffect들
     useEffect(() => {
         // graphRefreshTrigger 변화 감지하여 새로 추가된 노드 표시
-        if (props.graphRefreshTrigger) {
+        if (graphRefreshTrigger) {
             // 이 로직은 GraphView 내부에서 처리되므로 여기서는 기본 설정만
             setShowNewlyAdded(false);
             setNewlyAddedNodeNames([]);
         }
-    }, [props.graphRefreshTrigger]);
+    }, [graphRefreshTrigger]);
 
     useEffect(() => {
         // referencedNodes 변화 감지
-        if (props.referencedNodes && props.referencedNodes.length > 0) {
+        if (referencedNodes && referencedNodes.length > 0) {
             setShowReferenced(true);
         }
-    }, [props.referencedNodes]);
+    }, [referencedNodes]);
 
     // ✅ 수정: focusNodeNames 변화 감지 - 안전한 의존성 배열 사용
     useEffect(() => {
-        console.log('🎯 focusNodeNames 변화 감지:', props.focusNodeNames);
-        if (props.focusNodeNames && props.focusNodeNames.length > 0) {
+        console.log('🎯 focusNodeNames 변화 감지:', focusNodeNames);
+        if (focusNodeNames && focusNodeNames.length > 0) {
             console.log('✅ showFocus를 true로 설정');
             setShowFocus(true);
         }
-    }, [props.focusNodeNames]);
-
-    // ✅ 수정: 디버깅 로그를 별도 useEffect로 분리하고 조건부 실행
-    useEffect(() => {
-        // 개발 모드에서만 로그 출력
-        if (process.env.NODE_ENV === 'development') {
-            console.log('🔍 GraphViewWithModal 상태:', {
-                showFocus,
-                focusNodeNamesLength: props.focusNodeNames?.length || 0,
-                showReferenced,
-                referencedNodesLength: props.referencedNodes?.length || 0,
-                showNewlyAdded,
-                newlyAddedNodesLength: newlyAddedNodeNames?.length || 0
-            });
-        }
-    }, []);
+    }, [focusNodeNames]);
 
     // ESC로 닫기
     useEffect(() => {
@@ -69,90 +62,22 @@ function GraphViewWithModal(props) {
         return () => window.removeEventListener('keydown', handleKeyDown);
     }, []);
 
-    // 모달 바깥 클릭 시 닫기
-    const handleBackdropClick = (e) => {
-        if (modalRef.current && !modalRef.current.contains(e.target)) {
-            setIsFullscreen(false);
-        }
-    };
-
-    // 모달 드래그
-    const handleMouseDown = (e) => {
-        const modal = modalRef.current;
-        if (!modal) return;
-
-        const rect = modal.getBoundingClientRect();
-        offset.current = {
-            x: e.clientX - rect.left,
-            y: e.clientY - rect.top,
-        };
-
-        modal.style.transform = 'none';
-        modal.style.left = `${rect.left}px`;
-        modal.style.top = `${rect.top}px`;
-
-        const onMouseMove = (e) => {
-            const newLeft = e.clientX - offset.current.x;
-            const newTop = e.clientY - offset.current.y;
-            modal.style.left = `${newLeft}px`;
-            modal.style.top = `${newTop}px`;
-        };
-
-        const onMouseUp = () => {
-            window.removeEventListener('mousemove', onMouseMove);
-            window.removeEventListener('mouseup', onMouseUp);
-        };
-
-        window.addEventListener('mousemove', onMouseMove);
-        window.addEventListener('mouseup', onMouseUp);
-    };
-
-    // 리사이즈
-    const handleResizeMouseDown = (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        const modal = modalRef.current;
-        if (!modal) return;
-
-        const startWidth = modal.offsetWidth;
-        const startHeight = modal.offsetHeight;
-        const startX = e.clientX;
-        const startY = e.clientY;
-
-        const onMouseMove = (e) => {
-            const newWidth = Math.max(400, startWidth + (e.clientX - startX));
-            const newHeight = Math.max(300, startHeight + (e.clientY - startY));
-            modal.style.width = `${newWidth}px`;
-            modal.style.height = `${newHeight}px`;
-        };
-
-        const onMouseUp = () => {
-            window.removeEventListener('mousemove', onMouseMove);
-            window.removeEventListener('mouseup', onMouseUp);
-        };
-
-        window.addEventListener('mousemove', onMouseMove);
-        window.addEventListener('mouseup', onMouseUp);
-    };
-
     // 외부 창 열기 함수 개선
     const openExternalGraphWindow = () => {
-        const brainId = props.brainId || 'default-brain-id';
-
         const params = new URLSearchParams({
             brainId: brainId
         });
 
-        if (props.referencedNodes && props.referencedNodes.length > 0) {
-            params.set('referencedNodes', encodeURIComponent(JSON.stringify(props.referencedNodes)));
+        if (referencedNodes && referencedNodes.length > 0) {
+            params.set('referencedNodes', encodeURIComponent(JSON.stringify(referencedNodes)));
         }
 
-        if (props.focusNodeNames && props.focusNodeNames.length > 0) {
-            params.set('focusNodeNames', encodeURIComponent(JSON.stringify(props.focusNodeNames)));
+        if (focusNodeNames && focusNodeNames.length > 0) {
+            params.set('focusNodeNames', encodeURIComponent(JSON.stringify(focusNodeNames)));
         }
 
-        if (props.graphData) {
-            params.set('nodeCount', props.graphData.nodes?.length || 0);
+        if (onGraphDataUpdate) {
+            params.set('nodeCount', onGraphDataUpdate.nodes?.length || 0);
         }
 
         const url = `${window.location.origin}/graph-view?${params.toString()}`;
@@ -205,17 +130,19 @@ function GraphViewWithModal(props) {
         <div className="graph-view-wrapper">
             <div className="graph-with-button">
                 <GraphView
-                    {...props}
-                    isFullscreen={isFullscreen}
-                    referencedNodes={props.referencedNodes}
-                    focusNodeNames={props.focusNodeNames}
+                    brainId={brainId}
+                    height={height}
+                    referencedNodes={referencedNodes}
+                    focusNodeNames={focusNodeNames}
                     onTimelapse={timelapseFunctionRef}
-                    // ✅ 외부에서 제어할 수 있도록 상태 전달
+                    graphRefreshTrigger={graphRefreshTrigger}
+                    onGraphDataUpdate={onGraphDataUpdate}
+                    onGraphReady={onGraphReady}
+                    isFullscreen={isFullscreen}
                     externalShowReferenced={showReferenced}
                     externalShowFocus={showFocus}
                     externalShowNewlyAdded={showNewlyAdded}
                     onGraphViewReady={handleGraphViewReady}
-                    // ✅ 새로 추가된 노드 정보를 받는 콜백 추가
                     onNewlyAddedNodes={handleNewlyAddedNodes}
                 />
 
@@ -256,9 +183,9 @@ function GraphViewWithModal(props) {
                 )}
 
                 {/* 참고된 노드가 있을 때 정보 표시 */}
-                {showReferenced && props.referencedNodes && props.referencedNodes.length > 0 && (
+                {showReferenced && referencedNodes && referencedNodes.length > 0 && (
                     <div className="graph-popup">
-                        <span>참고된 노드: {props.referencedNodes.join(', ')}</span>
+                        <span>참고된 노드: {referencedNodes.join(', ')}</span>
                         <span className="close-x" onClick={() => {
                             console.log('🔥 참고된 노드 강조 해제');
                             setShowReferenced(false);
@@ -271,9 +198,9 @@ function GraphViewWithModal(props) {
                 )}
 
                 {/* ✅ 수정: 포커스 노드 팝업 - console.log 제거 */}
-                {showFocus && Array.isArray(props.focusNodeNames) && props.focusNodeNames.length > 0 && (
+                {showFocus && Array.isArray(focusNodeNames) && focusNodeNames.length > 0 && (
                     <div className="graph-popup">
-                        <span>소스로 생성된 노드: {props.focusNodeNames.join(', ')}</span>
+                        <span>소스로 생성된 노드: {focusNodeNames.join(', ')}</span>
                         <span
                             className="close-x"
                             onClick={() => {
@@ -293,5 +220,3 @@ function GraphViewWithModal(props) {
         </div>
     );
 }
-
-export default GraphViewWithModal;

--- a/frontend/src/components/panels/Insight/Graph/graphTimelapse.js
+++ b/frontend/src/components/panels/Insight/Graph/graphTimelapse.js
@@ -1,0 +1,77 @@
+import * as d3 from 'd3';
+import { easeCubicInOut } from 'd3-ease';
+
+/**
+ * 그래프 타임랩스 애니메이션 함수
+ * @param {Object} params - 파라미터 객체
+ * @param {Object} params.graphData - 그래프 데이터 (nodes, links)
+ * @param {Function} params.setIsAnimating - 애니메이션 상태 변경 함수
+ * @param {Function} params.setVisibleNodes - 보이는 노드 상태 변경 함수
+ * @param {Function} params.setVisibleLinks - 보이는 링크 상태 변경 함수
+ * @param {Object} params.fgRef - ForceGraph ref 객체
+ */
+export function startTimelapse({
+  graphData,
+  setIsAnimating,
+  setVisibleNodes,
+  setVisibleLinks,
+  fgRef
+}) {
+  const nodes = [...graphData.nodes];
+  const links = [...graphData.links];
+  const N = nodes.length;
+  if (N === 0) return;
+
+  const totalDuration = Math.min(6000, 800 + N * 80);
+  const fadeDuration = Math.max(200, Math.min(800, N * 10));
+
+  const shuffledNodes = d3.shuffle(nodes);
+  const appearTimes = shuffledNodes.map((_, i) =>
+    (i / (N - 1)) * (totalDuration - fadeDuration)
+  );
+
+  setIsAnimating(true);
+  setVisibleNodes([]);
+  setVisibleLinks([]);
+
+  if (fgRef.current) {
+    const currentZoom = fgRef.current.zoom();
+    fgRef.current.zoom(currentZoom, 0);
+  }
+
+  const startTime = performance.now();
+
+  const tick = now => {
+    const t = now - startTime;
+    const idx = Math.min(
+      N - 1,
+      Math.floor((t / (totalDuration - fadeDuration)) * (N - 1))
+    );
+
+    const visible = shuffledNodes.slice(0, idx + 1).map((n, i) => {
+      const dt = t - appearTimes[i];
+      const alpha = dt <= 0
+        ? 0
+        : dt >= fadeDuration
+          ? 1
+          : easeCubicInOut(dt / fadeDuration);
+      return { ...n, __opacity: alpha };
+    });
+
+    const visibleIds = new Set(visible.map(n => n.id));
+    const visibleLinks = links.filter(l =>
+      visibleIds.has(l.source) && visibleIds.has(l.target)
+    );
+
+    setVisibleNodes(visible);
+    setVisibleLinks(visibleLinks);
+
+    if (t < totalDuration) {
+      requestAnimationFrame(tick);
+    } else {
+      setIsAnimating(false);
+    }
+  };
+
+  requestAnimationFrame(tick);
+} 

--- a/frontend/src/components/panels/Insight/InsightPanel.jsx
+++ b/frontend/src/components/panels/Insight/InsightPanel.jsx
@@ -21,7 +21,7 @@ import {
   deleteMemo
 } from '../../../../api/backend';
 
-function MemoPanel({ selectedBrainId, collapsed, setCollapsed, referencedNodes = [], graphRefreshTrigger, onGraphDataUpdate, focusNodeNames = [] }) {
+function MemoPanel({ selectedBrainId, collapsed, setCollapsed, referencedNodes = [], graphRefreshTrigger, onGraphDataUpdate, focusNodeNames = [], onGraphReady }) {
   const projectId = selectedBrainId;
   const [showGraph, setShowGraph] = useState(true);
   const [showMemo, setShowMemo] = useState(true);
@@ -193,6 +193,7 @@ function MemoPanel({ selectedBrainId, collapsed, setCollapsed, referencedNodes =
                 focusNodeNames={focusNodeNames}
                 graphRefreshTrigger={graphRefreshTrigger}
                 onGraphDataUpdate={onGraphDataUpdate}
+                onGraphReady={onGraphReady}
               />
             </div>
           )}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #62 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- isChatReady 상태 추가 및 allReady 조건에 포함
- 전체 패널 준비가 완료될 때만 로딩 오버레이 해제
- onChatReady prop 추가, 채팅 내역 fetch 성공/실패 시 부모에 준비 상태 전달
- MainLayout의 allReady와 연동
- graphReady 상태 useState로 관리
- 데이터 로딩 성공/실패 시 setGraphReady(true/false)
- graphReady가 바뀔 때마다 onGraphReady 콜백으로 부모에 전달
- 불필요한 콜백 등록 useEffect, 사용하지 않는 변수 등 정리

## 💬리뷰 요구사항(선택)

> 없음
