### PR TITLE
그래프뷰 전체화면에서 노드 검색 시 생기는 버그 해결 (refs #77)

### DIFF
--- a/frontend/src/components/panels/Insight/Graph/GraphView.jsx
+++ b/frontend/src/components/panels/Insight/Graph/GraphView.jsx
@@ -39,6 +39,7 @@ function GraphView({
   onClearReferencedNodes,
   onClearFocusNodes,
   onClearNewlyAddedNodes,
+  fromFullscreen = false,
 }) {
 
   // === 그래프 컨테이너/크기 관련 ===
@@ -648,7 +649,7 @@ function GraphView({
         </div>
       )}
       {/* 참고된 노드가 있을 때 정보 표시 */}
-      {showReferenced && referencedNodesState && referencedNodesState.length > 0 && (
+      {(!fromFullscreen) && showReferenced && referencedNodesState && referencedNodesState.length > 0 && (
         <div className="graph-popup">
           <span>참고된 노드: {referencedNodesState.join(', ')}</span>
           <span className="close-x" onClick={() => {
@@ -687,7 +688,7 @@ function GraphView({
             transform: 'translate(12px, 8px)'
           }}
         >
-          노드 : {hoveredNode.name} <span style={{fontWeight:400, fontSize:13}}>(연결: {hoveredNode.linkCount})</span>
+          노드 : {hoveredNode.name} <span style={{ fontWeight: 400, fontSize: 13 }}>(연결: {hoveredNode.linkCount})</span>
         </div>
       )}
       {hoveredLink && (
@@ -701,15 +702,15 @@ function GraphView({
             color: '#6d28d9',
             borderRadius: 8,
             padding: '3px 10px',
-            fontSize: 16,
-            fontWeight: 600,
+            fontSize: 15,
+            fontWeight: 500,
             boxShadow: '0 2px 16px 0 #d6bbfc',
             zIndex: 1000,
             transform: 'translate(12px, 8px)'
           }}
         >
           <div>{hoveredLink.source?.name || hoveredLink.source} → {hoveredLink.target?.name || hoveredLink.target}</div>
-          <div style={{fontWeight:500, fontSize:14}}>관계 : {hoveredLink.relation || '관계'}</div>
+          <div style={{ fontWeight: 400, fontSize: 13 }}>관계 : {hoveredLink.relation || '관계'}</div>
         </div>
       )}
       {loading && (
@@ -850,7 +851,7 @@ function GraphView({
             // 테두리 색상
             if (isHovered) {
               ctx.strokeStyle = '#d6bbfc'; // 완전 연한 보라색 테두리
-              ctx.lineWidth = 9 / globalScale;
+              ctx.lineWidth = 7 / globalScale;
             } else if (isNewlyAdded || isFocus) {
               ctx.strokeStyle = isDarkMode ? '#60a5fa' : '#2196f3';
               ctx.lineWidth = 4 / globalScale;

--- a/frontend/src/components/panels/Insight/Graph/GraphViewForFullscreen.css
+++ b/frontend/src/components/panels/Insight/Graph/GraphViewForFullscreen.css
@@ -89,7 +89,8 @@
   flex: 1;
   border: none;
   outline: none;
-  padding: 12px 0;
+  padding: 13px 0;
+  margin-left: 10px;
   font-size: 14px;
   color: #1f2937;
   background: transparent;

--- a/frontend/src/components/panels/Insight/Graph/GraphViewForFullscreen.jsx
+++ b/frontend/src/components/panels/Insight/Graph/GraphViewForFullscreen.jsx
@@ -3,8 +3,10 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import GraphView from './GraphView';
 import './GraphViewForFullscreen.css';
+import { FiSearch, FiX, FiSun, FiMoon, FiSettings, FiRefreshCw, FiMapPin } from 'react-icons/fi';
 
 function GraphViewForFullscreen(props) {
+    const { isFullscreen = true, ...restProps } = props;
     const [allNodes, setAllNodes] = useState([]);
     const [searchQuery, setSearchQuery] = useState('');
     const [localReferencedNodes, setLocalReferencedNodes] = useState(props.referencedNodes || []);
@@ -18,6 +20,9 @@ function GraphViewForFullscreen(props) {
         const saved = localStorage.getItem('graphDarkMode');
         return saved ? JSON.parse(saved) : false;
     });
+
+    // 상단에 색상 변수 선언
+    const ICON_COLOR = isDarkMode ? 'white' : 'black';
 
     // ✅ 핵심 커스터마이징 + 3개 물리 설정
     const [graphSettings, setGraphSettings] = useState(() => {
@@ -136,8 +141,9 @@ function GraphViewForFullscreen(props) {
     return (
         <div className={`graph-fullscreen-container ${isDarkMode ? 'dark-mode' : ''}`}>
             <GraphView
-                {...props}
-                isFullscreen={true}
+                {...restProps}
+                isFullscreen={isFullscreen}
+                fromFullscreen={true}
                 referencedNodes={localReferencedNodes}
                 onGraphDataUpdate={handleGraphDataUpdate}
                 onNewlyAddedNodes={handleNewlyAddedNodes}
@@ -161,7 +167,7 @@ function GraphViewForFullscreen(props) {
                     <div className="toolbar-left">
                         <div className="fullscreen-search-container">
                             <div className="fullscreen-search-input-wrapper">
-                                <span className="fullscreen-search-icon">🔍</span>
+                                <FiSearch style={{ marginRight: 4, fontSize: 18, verticalAlign: 'middle', color: ICON_COLOR }} />
                                 <input
                                     id="fullscreen-node-search"
                                     type="text"
@@ -175,8 +181,9 @@ function GraphViewForFullscreen(props) {
                                         onClick={clearSearch}
                                         className="fullscreen-clear-search-btn"
                                         title="검색 초기화"
+                                        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                                     >
-                                        ✕
+                                        <FiX color={ICON_COLOR} />
                                     </button>
                                 )}
                             </div>
@@ -195,7 +202,7 @@ function GraphViewForFullscreen(props) {
                             title={`${isDarkMode ? '라이트' : '다크'}모드 (⌘D)`}
                         >
                             <span className="fullscreen-btn-icon">
-                                {isDarkMode ? '☀️' : '🌙'}
+                                {isDarkMode ? <FiSun color={ICON_COLOR} /> : <FiMoon color={ICON_COLOR} />}
                             </span>
                             <span className="btn-text">
                                 {isDarkMode ? '라이트' : '다크'}
@@ -207,13 +214,12 @@ function GraphViewForFullscreen(props) {
                             className={`fullscreen-control-btn advanced-toggle ${showAdvancedControls ? 'active' : ''}`}
                             title="고급 컨트롤 토글 (⌘K)"
                         >
-                            <span className="fullscreen-btn-icon">⚙️</span>
+                            <span className="fullscreen-btn-icon"><FiSettings color={ICON_COLOR} /></span>
                             <span className="btn-text">고급</span>
                         </button>
 
                         <button
                             onClick={() => {
-                                console.log('🔄 새로고침 버튼 클릭됨');
                                 if (props.onRefresh) {
                                     props.onRefresh();
                                 } else {
@@ -227,7 +233,7 @@ function GraphViewForFullscreen(props) {
                             className="fullscreen-control-btn refresh-btn"
                             title="그래프 새로고침"
                         >
-                            <span className="fullscreen-btn-icon">🔄</span>
+                            <span className="fullscreen-btn-icon"><FiRefreshCw color={ICON_COLOR} /></span>
                             <span className="btn-text">새로고침</span>
                         </button>
 
@@ -239,7 +245,7 @@ function GraphViewForFullscreen(props) {
                                     className="fullscreen-control-btn fullscreen-clear-btn"
                                     title="하이라이트 해제"
                                 >
-                                    <span className="fullscreen-btn-icon">✕</span>
+                                    <span className="fullscreen-btn-icon"><FiX color={ICON_COLOR} /></span>
                                     <span className="btn-text">해제</span>
                                 </button>
                             )}
@@ -446,7 +452,7 @@ function GraphViewForFullscreen(props) {
                     <div className="fullscreen-status-left">
                         {(localReferencedNodes.length > 0 || newlyAddedNodes.length > 0) && (
                             <div className="fullscreen-highlighted-nodes">
-                                <span className="fullscreen-status-icon">📍</span>
+                                <span className="fullscreen-status-icon"><FiMapPin color={ICON_COLOR} /></span>
                                 <span className="fullscreen-status-text">
                                     {props.focusNodeNames && props.focusNodeNames.length > 0 ? '포커스' :
                                         newlyAddedNodes.length > 0 ? '새로 추가' : '하이라이트'}:


### PR DESCRIPTION
## #️⃣연관된 이슈

> #77 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
그래프뷰 전체화면을 누르고 노드 검색을 누를 때 기존 그래프뷰에 보내지는 코드때문에 참고된 노드가 같이 떠 보이는데 GraphView.jsx에 코드를 보낼때 props로 isFullScreen의 변수를 같이 넘겨줘서 전체화면일 때는 해당 문구가 안뜨게 설정

## 💬리뷰 요구사항(선택)

> 없음
