### PR TITLE
100 파일 이름 형식 제한 걸기

### DIFF
--- a/backend/routers/mdRouter.py
+++ b/backend/routers/mdRouter.py
@@ -72,6 +72,22 @@ async def update_mdfile(md_id: int, mdfile_data: MDFileUpdate):
         if not sqlite_handler.get_brain(mdfile_data.brain_id):
             raise HTTPException(status_code=404, detail="Brain 엔티티를 찾을 수 없습니다")
 
+    # 파일명 제한 검증
+    if mdfile_data.md_title is not None:
+        name = mdfile_data.md_title
+        # 1. 길이 제한
+        if not (1 <= len(name) <= 100):
+            raise HTTPException(status_code=400, detail="파일명은 1~100자여야 합니다.")
+        # 2. 공백만 입력 금지
+        if name.strip() == "":
+            raise HTTPException(status_code=400, detail="파일명에 공백만 입력할 수 없습니다.")
+        # 3. 특수문자 제한
+        if re.search(r'[\\/:*?"<>|]', name):
+            raise HTTPException(status_code=400, detail="파일명에 / \\ : * ? \" < > | 문자를 사용할 수 없습니다.")
+        # 4. 점(.)으로 시작/끝 금지
+        if name.startswith('.') or name.endswith('.'):
+            raise HTTPException(status_code=400, detail="파일명은 .(점)으로 시작하거나 끝날 수 없습니다.")
+
     try:
         updated = sqlite_handler.update_mdfile(
             md_id=md_id,

--- a/backend/routers/memoRouter.py
+++ b/backend/routers/memoRouter.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, Field
 from typing import List, Optional
 from sqlite_db import SQLiteHandler
 import logging
+import re
 
 sqlite_handler = SQLiteHandler()
 
@@ -74,6 +75,23 @@ async def update_memo(memo_id: int, memo_data: MemoUpdate):
     if memo_data.brain_id:
         if not sqlite_handler.get_brain(memo_data.brain_id):
             raise HTTPException(status_code=404, detail="Brain 엔티티를 찾을 수 없습니다")
+
+    # 파일명 제한 검증
+    if memo_data.memo_title is not None:
+        name = memo_data.memo_title
+        # 1. 길이 제한
+        if not (1 <= len(name) <= 100):
+            raise HTTPException(status_code=400, detail="파일명은 1~100자여야 합니다.")
+        # 2. 공백만 입력 금지
+        if name.strip() == "":
+            raise HTTPException(status_code=400, detail="파일명에 공백만 입력할 수 없습니다.")
+        # 3. 특수문자 제한
+        if re.search(r'[\\/:*?"<>|]', name):
+            raise HTTPException(status_code=400, detail="파일명에 / \\ : * ? \" < > | 문자를 사용할 수 없습니다.")
+        # 4. 점(.)으로 시작/끝 금지
+        if name.startswith('.') or name.endswith('.'):
+            raise HTTPException(status_code=400, detail="파일명은 .(점)으로 시작하거나 끝날 수 없습니다.")
+
     try:
         updated = sqlite_handler.update_memo(
             memo_id,

--- a/backend/routers/pdfRouter.py
+++ b/backend/routers/pdfRouter.py
@@ -81,6 +81,23 @@ async def update_pdf(pdf_id: int, pdf_data: PdfUpdate):
     if pdf_data.brain_id and not sqlite_handler.get_brain(pdf_data.brain_id):
         raise HTTPException(status_code=404, detail="Brain 엔티티를 찾을 수 없습니다")
 
+    # 파일명 제한 검증
+    if pdf_data.pdf_title is not None:
+        name = pdf_data.pdf_title
+        # 1. 길이 제한
+        if not (1 <= len(name) <= 100):
+            raise HTTPException(status_code=400, detail="파일명은 1~100자여야 합니다.")
+        # 2. 공백만 입력 금지
+        if name.strip() == "":
+            raise HTTPException(status_code=400, detail="파일명에 공백만 입력할 수 없습니다.")
+        # 3. 특수문자 제한
+        import re
+        if re.search(r'[\\/:*?"<>|]', name):
+            raise HTTPException(status_code=400, detail="파일명에 / \\ : * ? \" < > | 문자를 사용할 수 없습니다.")
+        # 4. 점(.)으로 시작/끝 금지
+        if name.startswith('.') or name.endswith('.'):
+            raise HTTPException(status_code=400, detail="파일명은 .(점)으로 시작하거나 끝날 수 없습니다.")
+
     try:
         updated = sqlite_handler.update_pdf(
             pdf_id=pdf_id,

--- a/backend/routers/textFileRouter.py
+++ b/backend/routers/textFileRouter.py
@@ -71,6 +71,23 @@ async def update_textfile(txt_id: int, textfile_data: TextFileUpdate):
         if not sqlite_handler.get_brain(textfile_data.brain_id):
             raise HTTPException(status_code=404, detail="Brain 엔티티를 찾을 수 없습니다")
 
+    # 파일명 제한 검증
+    if textfile_data.txt_title is not None:
+        name = textfile_data.txt_title
+        # 1. 길이 제한
+        if not (1 <= len(name) <= 100):
+            raise HTTPException(status_code=400, detail="파일명은 1~100자여야 합니다.")
+        # 2. 공백만 입력 금지
+        if name.strip() == "":
+            raise HTTPException(status_code=400, detail="파일명에 공백만 입력할 수 없습니다.")
+        # 3. 특수문자 제한
+        import re
+        if re.search(r'[\\/:*?"<>|]', name):
+            raise HTTPException(status_code=400, detail="파일명에 / \\ : * ? \" < > | 문자를 사용할 수 없습니다.")
+        # 4. 점(.)으로 시작/끝 금지
+        if name.startswith('.') or name.endswith('.'):
+            raise HTTPException(status_code=400, detail="파일명은 .(점)으로 시작하거나 끝날 수 없습니다.")
+
     try:
         updated = sqlite_handler.update_textfile(
             txt_id=txt_id,

--- a/frontend/src/components/panels/Source/FileView.jsx
+++ b/frontend/src/components/panels/Source/FileView.jsx
@@ -295,7 +295,14 @@ export default function FileView({
         onFileUploaded();
       }
     } catch (e) {
-      alert('이름 변경 실패');
+      // 백엔드에서 온 에러 메시지 추출
+      let msg = '이름 변경 실패';
+      if (e && e.response && e.response.data && e.response.data.detail) {
+        msg = e.response.data.detail;
+      } else if (e && e.message) {
+        msg = e.message;
+      }
+      toast.error(msg);
     } finally {
       setEditingId(null);
     }
@@ -437,9 +444,11 @@ export default function FileView({
                   }}
                   style={{ width: '120px', marginRight: '2px' }}
                 />
-                <span style={{ color: '#888', fontSize: '0.95em', userSelect: 'none' }}>
-                  {f.name.slice(f.name.lastIndexOf('.'))}
-                </span>
+                {f.filetype !== 'memo' && (
+                  <span style={{ color: '#888', fontSize: '0.95em', userSelect: 'none' }}>
+                    {f.name.slice(f.name.lastIndexOf('.'))}
+                  </span>
+                )}
               </span>
             ) : (
               <span className="file-name">{f.name}</span>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #99, #100

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- **소스 업로드 UX 개선**
  - 소스 업로드가 완료된 후에만 목록이 갱신되도록 하여, 업로드 중 중복 표시 및 UX 혼란 방지 (refs #99)
- **파일명 변경 시 백엔드 검증 및 안내 강화**
  - 파일명 변경 시 특수문자, 길이, 공백, 점(.) 등 일반적인 파일명 제한을 백엔드에서 검증 (refs #100)
  - 텍스트, PDF, 메모, MD, DOCX 파일 모두 적용
- **에러 안내 UX 개선**
  - 파일명 변경 실패 시 백엔드에서 반환된 에러 메시지를 toast로 사용자에게 안내 (alert 제거, UX 향상)
- **코드 리팩토링**
  - 파일 type별 id/title/path 추출 로직을 typeMeta 맵으로 통합하여 중복 분기 제거 및 가독성/유지보수성 향상

## 💬리뷰 요구사항(선택)

> 없음
